### PR TITLE
fix index bug.the original index is a float datatype

### DIFF
--- a/lib/rpn_msr/proposal_target_layer_tf.py
+++ b/lib/rpn_msr/proposal_target_layer_tf.py
@@ -84,7 +84,7 @@ def _get_bbox_regression_labels(bbox_target_data, num_classes):
     inds = np.where(clss > 0)[0]
     for ind in inds:
         cls = clss[ind]
-        start = 4 * cls
+        start = int(4 * cls)
         end = start + 4
         bbox_targets[ind, start:end] = bbox_target_data[ind, 1:]
         bbox_inside_weights[ind, start:end] = cfg.TRAIN.BBOX_INSIDE_WEIGHTS
@@ -122,7 +122,7 @@ def _sample_rois(all_rois, gt_boxes, fg_rois_per_image, rois_per_image, num_clas
     fg_inds = np.where(max_overlaps >= cfg.TRAIN.FG_THRESH)[0]
     # Guard against the case when an image has fewer than fg_rois_per_image
     # foreground RoIs
-    fg_rois_per_this_image = min(fg_rois_per_image, fg_inds.size)
+    fg_rois_per_this_image = int(min(fg_rois_per_image, fg_inds.size))
     # Sample foreground regions without replacement
     if fg_inds.size > 0:
         fg_inds = npr.choice(fg_inds, size=fg_rois_per_this_image, replace=False)


### PR DESCRIPTION
The error info is presented as follows:

`Traceback (most recent call last):
  File "/home/elias/code/tensorflow-env-0-11/local/lib/python2.7/site-packages/tensorflow/python/ops/script_ops.py", line 83, in __call__
    ret = func(*args)
  File "/home/elias/code/Faster-RCNN_TF/tools/../lib/rpn_msr/proposal_target_layer_tf.py", line 48, in proposal_target_layer
    rois_per_image, _num_classes)
  File "/home/elias/code/Faster-RCNN_TF/tools/../lib/rpn_msr/proposal_target_layer_tf.py", line 154, in _sample_rois
    _get_bbox_regression_labels(bbox_target_data, num_classes)
  File "/home/elias/code/Faster-RCNN_TF/tools/../lib/rpn_msr/proposal_target_layer_tf.py", line 90, in _get_bbox_regression_labels
    bbox_targets[ind, start:end] = bbox_target_data[ind, 1:]
TypeError: slice indices must be integers or None or have an __index__ method`
`Traceback (most recent call last):
  File "/home/elias/code/tensorflow-env-0-11/local/lib/python2.7/site-packages/tensorflow/python/ops/script_ops.py", line 83, in __call__
    ret = func(*args)
  File "/home/elias/code/Faster-RCNN_TF/tools/../lib/rpn_msr/proposal_target_layer_tf.py", line 48, in proposal_target_layer
    rois_per_image, _num_classes)
  File "/home/elias/code/Faster-RCNN_TF/tools/../lib/rpn_msr/proposal_target_layer_tf.py", line 139, in _sample_rois
    bg_inds = npr.choice(bg_inds, size=bg_rois_per_this_image, replace=False)
  File "mtrand.pyx", line 1176, in mtrand.RandomState.choice (numpy/random/mtrand/mtrand.c:18822)
TypeError: 'numpy.float64' object cannot be interpreted as an index
`